### PR TITLE
Update GitHub Action for Container CI

### DIFF
--- a/.github/workflows/dockercompose.yml
+++ b/.github/workflows/dockercompose.yml
@@ -1,6 +1,12 @@
 name: Docker Compose CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master  # Push events on master branch
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
 


### PR DESCRIPTION
If someone from maintainers decided to create a new branch in local repositories, we will fire up 2 check-runs instead of one. This change invalidates it.
Signed-off-by: Martin Styk <mastyk@redhat.com>