### PR TITLE
Update Beaker setup role

### DIFF
--- a/dev/ansible/roles/beaker/setup/packages/tasks/main.yml
+++ b/dev/ansible/roles/beaker/setup/packages/tasks/main.yml
@@ -43,9 +43,8 @@
     - xorg-x11-server-Xvfb
     - pylint
     - pytest
-    - PyXML  # needed by beah and used on Jenkins in dogfood tests
     - xz  # to import database dumps
-    - centos-release-openstack-juno # OpenStack
+    - centos-release-openstack-stein  # OpenStack
 
 - name: install OpenStack deps
   sudo: yes

--- a/dev/ansible/roles/beaker/setup/packages/tasks/main.yml
+++ b/dev/ansible/roles/beaker/setup/packages/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: clone the beaker repository
   git:
-    repo: git://git.beaker-project.org/beaker
+    repo: https://github.com/beaker-project/beaker.git
     depth: 1
     dest: /tmp/beaker
     version: develop


### PR DESCRIPTION
1. Git repository on beaker-project.org is no longer main source
2. Dependencies for CentOS7 were corrected. 